### PR TITLE
added case class for NeuralNetConfiguration factory / type-safe classes for LossFunction etc.

### DIFF
--- a/src/main/scala/org/deeplearning4s/nn/conf/ActivationFunction.scala
+++ b/src/main/scala/org/deeplearning4s/nn/conf/ActivationFunction.scala
@@ -1,0 +1,17 @@
+package org.deeplearning4s.nn.conf
+
+/*
+  org.deeplearning4s.nn.conf.ActivationFunction stands for each implemented class of org.nd4j.linalg.api.activation.ActivationFunction
+  @see http://nd4j.org/apidocs/org/nd4j/linalg/api/activation/ActivationFunction.html
+ */
+sealed class ActivationFunction(val name:String)
+case object Sigmoid extends ActivationFunction("sigmoid")
+case object Tanh extends ActivationFunction("tanh")
+case object Softmax extends ActivationFunction("softmax")
+case object Relu extends ActivationFunction("relu")
+case object Exp extends ActivationFunction("exp")
+case object HardTanh extends ActivationFunction("hardtanh")
+case object Linear extends ActivationFunction("linear")
+case object MaxOut extends ActivationFunction("maxout")
+case object RectifiedLinear extends ActivationFunction("rectifiedlinear")
+case object RoundedLinear extends ActivationFunction("roundedlinear")

--- a/src/main/scala/org/deeplearning4s/nn/conf/LossFunction.scala
+++ b/src/main/scala/org/deeplearning4s/nn/conf/LossFunction.scala
@@ -1,0 +1,182 @@
+package org.deeplearning4s.nn.conf
+
+import org.nd4j.linalg.lossfunctions.LossFunctions.{LossFunction => LF}
+
+/*
+  LossFunction stands for org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction.
+  CustomLossFunction stands for all implemented classes of org.nd4j.linalg.api.ops.Op.
+ */
+
+sealed class LossFunction(val value:LF)
+object LossFunction {
+  case object EXPLL extends LossFunction(LF.EXPLL)
+
+  case object MCXENT extends LossFunction(LF.MCXENT)
+
+  case object MSE extends LossFunction(LF.MSE)
+
+  case object NEGATIVELOGLIKELIHOOD extends LossFunction(LF.NEGATIVELOGLIKELIHOOD)
+
+  case object RECONSTRUCTION_CROSSENTROPY extends LossFunction(LF.RECONSTRUCTION_CROSSENTROPY)
+
+  case object RMSE_XENT extends LossFunction(LF.RMSE_XENT)
+
+  case object SQUARED_LOSS extends LossFunction(LF.SQUARED_LOSS)
+
+  case object XENT extends LossFunction(LF.XENT)
+
+  sealed class Custom(val name: String) extends LossFunction(LF.CUSTOM)
+
+  case object Max extends Custom("Max")
+
+  case object MulOp extends Custom("MulOp")
+
+  case object Eps extends Custom("Eps")
+
+  case object Negative extends Custom("Negative")
+
+  case object EqualTo extends Custom("EqualTo")
+
+  case object Round extends Custom("Round")
+
+  case object CosineSimilarity extends Custom("CosineSimilarity")
+
+  case object SoftMaxDerivative extends Custom("SoftMaxDerivative")
+
+  case object EuclideanDistance extends Custom("EuclideanDistance")
+
+  case object Abs extends Custom("Abs")
+
+  case object ScalarLessThanOrEqual extends Custom("ScalarLessThanOrEqual")
+
+  case object ScalarAdd extends Custom("ScalarAdd")
+
+  case object Exp extends Custom("Exp")
+
+  case object ScalarGreaterThan extends Custom("ScalarGreaterThan")
+
+  case object Mean extends Custom("Mean")
+
+  case object DivOp extends Custom("DivOp")
+
+  case object Ceil extends Custom("Ceil")
+
+  case object Prod extends Custom("Prod")
+
+  case object MaxOut extends Custom("MaxOut")
+
+  case object Cos extends Custom("Cos")
+
+  case object RDivOp extends Custom("RDivOp")
+
+  case object RSubOp extends Custom("RSubOp")
+
+  case object ScalarMax extends Custom("ScalarMax")
+
+  case object Dot extends Custom("Dot")
+
+  case object Variance extends Custom("Variance")
+
+  case object ScalarDivision extends Custom("ScalarDivision")
+
+  case object HardTanhDerivative extends Custom("HardTanhDerivative")
+
+  case object NotEqualTo extends Custom("NotEqualTo")
+
+  case object SigmoidDerivative extends Custom("SigmoidDerivative")
+
+  case object ScalarSubtraction extends Custom("ScalarSubtraction")
+
+  case object Bias extends Custom("Bias")
+
+  case object Sqrt extends Custom("Sqrt")
+
+  case object Sum extends Custom("Sum")
+
+  case object VectorIFFT extends Custom("VectorIFFT")
+
+  case object ATan extends Custom("ATan")
+
+  case object GreaterThan extends Custom("GreaterThan")
+
+  case object ASin extends Custom("ASin")
+
+  case object ScalarNotEquals extends Custom("ScalarNotEquals")
+
+  case object ScalarMultiplication extends Custom("ScalarMultiplication")
+
+  case object Identity extends Custom("Identity")
+
+  case object StandardDeviation extends Custom("StandardDeviation")
+
+  case object ScalarSetValue extends Custom("ScalarSetValue")
+
+  case object HardTanh extends Custom("HardTanh")
+
+  case object Stabilize extends Custom("Stabilize")
+
+  case object GreaterThanOrEqual extends Custom("GreaterThanOrEqual")
+
+  case object Floor extends Custom("Floor")
+
+  case object NormMax extends Custom("NormMax")
+
+  case object ScalarGreaterThanOrEqual extends Custom("ScalarGreaterThanOrEqual")
+
+  case object Norm1 extends Custom("Norm1")
+
+  case object Pow extends Custom("Pow")
+
+  case object ScalarReverseSubtraction extends Custom("ScalarReverseSubtraction")
+
+  case object Norm2 extends Custom("Norm2")
+
+  case object ScalarLessThan extends Custom("ScalarLessThan")
+
+  case object SetRange extends Custom("SetRange")
+
+  case object LessThan extends Custom("LessThan")
+
+  case object SubOp extends Custom("SubOp")
+
+  case object LessThanOrEqual extends Custom("LessThanOrEqual")
+
+  case object CopyOp extends Custom("CopyOp")
+
+  case object SoftMax extends Custom("SoftMax")
+
+  case object Sigmoid extends Custom("Sigmoid")
+
+  case object RectifedLinear extends Custom("RectifedLinear")
+
+  case object VectorFFT extends Custom("VectorFFT")
+
+  case object Log extends Custom("Log")
+
+  case object Tanh extends Custom("Tanh")
+
+  case object OneMinus extends Custom("OneMinus")
+
+  case object IAMax extends Custom("IAMax")
+
+  case object ManhattanDistance extends Custom("ManhattanDistance")
+
+  case object Sign extends Custom("Sign")
+
+  case object ScalarEquals extends Custom("ScalarEquals")
+
+  case object ACos extends Custom("ACos")
+
+  case object LinearIndex extends Custom("LinearIndex")
+
+  case object Ones extends Custom("Ones")
+
+  case object AddOp extends Custom("AddOp")
+
+  case object ScalarReverseDivision extends Custom("ScalarReverseDivision")
+
+  case object Sin extends Custom("Sin")
+
+  case object Min extends Custom("Min")
+
+}

--- a/src/main/scala/org/deeplearning4s/nn/conf/MultiLayerConf.scala
+++ b/src/main/scala/org/deeplearning4s/nn/conf/MultiLayerConf.scala
@@ -1,4 +1,4 @@
-package org.deeplearning4s.nn.multilayer
+package org.deeplearning4s.nn.conf
 
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration.Builder
 import org.deeplearning4j.nn.conf.`override`.ConfOverride
@@ -6,19 +6,19 @@ import org.deeplearning4j.nn.conf.{InputPreProcessor, MultiLayerConfiguration, N
 
 import scala.collection.JavaConverters._
 
-object MultiLayerConf {
-  def apply(
-             hiddenLayerSizes: Array[Int],
-             useDropConnect: Boolean = false,
-             pretrain: Boolean = false,
-             useRBMPropUpAsActivations: Boolean = false,
-             dampingFactor: Double = 100D,
-             backward: Boolean = false,
-             inputPreProcessors: Map[Int, InputPreProcessor] = Map.empty,
-             preProcessors: Map[Int, OutputPreProcessor] = Map.empty,
-             confs: Seq[NeuralNetConfiguration] = Nil,
-             confOverrides: Map[Int, ConfOverride] = Map.empty
-             ): MultiLayerConfiguration = {
+case class MultiLayerConf(
+                           hiddenLayerSizes: Array[Int],
+                           useDropConnect: Boolean = false,
+                           pretrain: Boolean = false,
+                           useRBMPropUpAsActivations: Boolean = false,
+                           dampingFactor: Double = 100D,
+                           backward: Boolean = false,
+                           inputPreProcessors: Map[Int, InputPreProcessor] = Map.empty,
+                           preProcessors: Map[Int, OutputPreProcessor] = Map.empty,
+                           confs: Seq[NeuralNetConfiguration] = Nil,
+                           confOverrides: Map[Int, ConfOverride] = Map.empty
+                           ) {
+  def asJava: MultiLayerConfiguration = {
     val builder = new Builder()
       .hiddenLayerSizes(hiddenLayerSizes: _*)
       .useDropConnect(useDropConnect)

--- a/src/main/scala/org/deeplearning4s/nn/conf/NeuralNetConf.scala
+++ b/src/main/scala/org/deeplearning4s/nn/conf/NeuralNetConf.scala
@@ -1,0 +1,66 @@
+package org.deeplearning4s.nn.conf
+
+import org.deeplearning4j.nn.api.OptimizationAlgorithm
+import org.deeplearning4j.nn.conf.NeuralNetConfiguration
+import org.deeplearning4j.nn.conf.distribution.{Distribution, NormalDistribution}
+import org.deeplearning4j.nn.conf.layers.{ConvolutionLayer, Layer, RBM}
+import org.deeplearning4j.nn.conf.stepfunctions.{DefaultStepFunction, StepFunction}
+import org.deeplearning4j.nn.weights.WeightInit
+import org.deeplearning4s.nn.conf.LossFunction.{Custom, RECONSTRUCTION_CROSSENTROPY}
+import scala.collection.JavaConverters._
+
+case class NeuralNetConf(layer: Layer,
+                         sparsity: Double = 1f,
+                         useAdaGrad: Boolean = true,
+                         learningRate: Double = 1e-1D,
+                         k: Int = 1,
+                         corruptionLevel: Double = 3e-1D,
+                         numIterations: Int = 100,
+                         momentum: Double = 0.5D,
+                         l2: Double = 0f,
+                         useRegularization: Boolean = false,
+                         momentumAfter: Map[Int, Double] = Map.empty,
+                         resetAdaGradIterations: Int = -1,
+                         dropOut: Double = 0,
+                         applySparsity: Boolean = false,
+                         weightInit: WeightInit = WeightInit.VI,
+                         optimizationAlgo: OptimizationAlgorithm = OptimizationAlgorithm.CONJUGATE_GRADIENT,
+                         lossFunction:LossFunction = RECONSTRUCTION_CROSSENTROPY,
+                         constrainGradientToUnitNorm: Boolean = false,
+                         seed: Long = System.currentTimeMillis(),
+                         dist: Distribution = new NormalDistribution(1e-3, 1),
+                         nIn: Int = 0,
+                         nOut: Int = 0,
+                         activationFunction: ActivationFunction = Sigmoid,
+                         visibleUnit: RBM.VisibleUnit = RBM.VisibleUnit.BINARY,
+                         hiddenUnit: RBM.HiddenUnit = RBM.HiddenUnit.BINARY,
+                         weightShape: Array[Int] = null,
+                         filterSize: Array[Int] = Array(2, 2, 2, 2),
+                         stride: Array[Int] = Array(2, 2),
+                         featureMapSize: Array[Int] = Array(2, 2),
+                         kernel: Int = 5,
+                         batchSize: Int = 100,
+                         numLineSearchIterations: Int = 100,
+                         minimize: Boolean = false,
+                         convolutionType: ConvolutionLayer.ConvolutionType = ConvolutionLayer.ConvolutionType.MAX,
+                         l1: Double = 0.0,
+                         rmsDecay: Double = 0f,
+                         stepFunction: StepFunction = new DefaultStepFunction()
+                          ) {
+  def asJava: NeuralNetConfiguration = {
+    val ma = momentumAfter.map { case (i, d) => Integer.valueOf(i) -> (d: java.lang.Double)}.toMap.asJava
+    val customLossFunction = lossFunction match {
+      case c:Custom => c.name
+      case _  => null
+    }
+    val conf = new NeuralNetConfiguration(sparsity, useAdaGrad, learningRate, k,
+      corruptionLevel, numIterations, momentum, l2, useRegularization, ma,
+      resetAdaGradIterations, dropOut, applySparsity, weightInit, optimizationAlgo, lossFunction.value,
+      constrainGradientToUnitNorm, null, seed,
+      dist, nIn, nOut, activationFunction.name, visibleUnit, hiddenUnit, weightShape, filterSize, stride, featureMapSize, kernel
+      , batchSize, numLineSearchIterations, minimize, layer, convolutionType, l1, customLossFunction)
+    conf.setRmsDecay(rmsDecay)
+    conf.setStepFunction(stepFunction)
+    conf
+  }
+}

--- a/src/test/scala/org/deeplearning4j/nn/conf/MultiLayerConfTest.scala
+++ b/src/test/scala/org/deeplearning4j/nn/conf/MultiLayerConfTest.scala
@@ -2,7 +2,7 @@ package org.deeplearning4j.nn.conf
 
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration.Builder
 import org.deeplearning4j.nn.conf.`override`.ConfOverride
-import org.deeplearning4s.nn.multilayer.MultiLayerConf
+import org.deeplearning4s.nn.conf.MultiLayerConf
 import org.nd4j.linalg.api.ndarray.INDArray
 import org.scalatest.FlatSpec
 import scala.collection.JavaConverters._
@@ -36,7 +36,7 @@ class MultiLayerConfTest extends FlatSpec {
       preProcessors = preProcessorsV,
       confs = confsV,
       confOverrides = confOverridesV
-    )
+    ).asJava
 
     assert(mlc.hiddenLayerSizes == hiddenLayerSizesV)
     assert(mlc.useDropConnect == useDropConnectV)

--- a/src/test/scala/org/deeplearning4j/nn/conf/NeuralNetConfTest.scala
+++ b/src/test/scala/org/deeplearning4j/nn/conf/NeuralNetConfTest.scala
@@ -1,0 +1,100 @@
+package org.deeplearning4j.nn.conf
+
+import org.deeplearning4j.nn.api.OptimizationAlgorithm
+import org.deeplearning4j.nn.conf.distribution.{Distribution, NormalDistribution}
+import org.deeplearning4j.nn.conf.layers.{ConvolutionLayer, Layer, RBM}
+import org.deeplearning4j.nn.conf.stepfunctions.StepFunction
+import org.deeplearning4j.nn.weights.WeightInit
+import org.deeplearning4s.nn.conf.LossFunction.Max
+import org.deeplearning4s.nn.conf.{ActivationFunction, NeuralNetConf, Sigmoid}
+import org.scalatest.FlatSpec
+
+import scala.collection.JavaConverters._
+
+class NeuralNetConfTest extends FlatSpec {
+  "NeuralNetConf" should "set each property to MultiLayerConfiguration instance correctly" in {
+    val layer: Layer = new Layer {}
+    val sparsity: Double = 2f
+    val useAdaGrad: Boolean = false
+    val learningRate: Double = 1e-2D
+    val k: Int = 2
+    val corruptionLevel: Double = 3e-2D
+    val numIterations: Int = 200
+    val momentum: Double = 1D
+    val l2: Double = 1f
+    val useRegularization: Boolean = true
+    val momentumAfter: Map[Int, Double] = Map(1 -> 1.0D)
+    val resetAdaGradIterations: Int = -2
+    val dropOut: Double = 1
+    val applySparsity: Boolean = true
+    val weightInit: WeightInit = WeightInit.UNIFORM
+    val optimizationAlgo: OptimizationAlgorithm = OptimizationAlgorithm.HESSIAN_FREE
+    val lossFunction = Max
+    val constrainGradientToUnitNorm: Boolean = true
+    val seed: Long = System.currentTimeMillis()
+    val dist: Distribution = new NormalDistribution(1e-3, 1)
+    val nIn: Int = 0
+    val nOut: Int = 0
+    val activationFunction: ActivationFunction = Sigmoid
+    val visibleUnit: RBM.VisibleUnit = RBM.VisibleUnit.BINARY
+    val hiddenUnit: RBM.HiddenUnit = RBM.HiddenUnit.BINARY
+    val weightShape: Array[Int] = Array(2)
+    val filterSize: Array[Int] = Array(1)
+    val stride: Array[Int] = Array(3)
+    val featureMapSize: Array[Int] = Array(1, 1)
+    val kernel: Int = 6
+    val batchSize: Int = 200
+    val numLineSearchIterations: Int = 200
+    val minimize: Boolean = true
+    val convolutionType: ConvolutionLayer.ConvolutionType = ConvolutionLayer.ConvolutionType.SUM
+    val l1: Double = 1.0D
+    val rmsDecay: Double = 1f
+    val stepFunction: StepFunction = new StepFunction
+
+    val conf = NeuralNetConf(layer, sparsity, useAdaGrad, learningRate, k, corruptionLevel, numIterations, momentum, l2, useRegularization,
+      momentumAfter, resetAdaGradIterations, dropOut, applySparsity, weightInit, optimizationAlgo,
+      lossFunction, constrainGradientToUnitNorm, seed, dist, nIn, nOut,
+      activationFunction, visibleUnit, hiddenUnit, weightShape, filterSize,
+      stride, featureMapSize, kernel, batchSize, numLineSearchIterations, minimize,
+      convolutionType, l1, rmsDecay, stepFunction).asJava
+
+    assert(conf.layer == layer)
+    assert(conf.getSparsity == sparsity)
+    assert(conf.isUseAdaGrad == useAdaGrad)
+    assert(conf.getLr == learningRate)
+    assert(conf.k == k)
+    assert(conf.corruptionLevel == corruptionLevel)
+    assert(conf.numIterations == numIterations)
+    assert(conf.momentum == momentum)
+    assert(conf.l2 == l2)
+    assert(conf.useRegularization == useRegularization)
+    assert(conf.momentumAfter.asScala == momentumAfter)
+    assert(conf.resetAdaGradIterations == resetAdaGradIterations)
+    assert(conf.dropOut == dropOut)
+    assert(conf.applySparsity == applySparsity)
+    assert(conf.getWeightInit == weightInit)
+    assert(conf.optimizationAlgo == optimizationAlgo)
+    assert(conf.lossFunction == lossFunction.value)
+    assert(conf.constrainGradientToUnitNorm == constrainGradientToUnitNorm)
+    assert(conf.seed == seed)
+    assert(conf.dist == dist)
+    assert(conf.nIn == nIn)
+    assert(conf.nOut == nOut)
+    assert(conf.activationFunction == activationFunction.name)
+    assert(conf.getVisibleUnit == visibleUnit)
+    assert(conf.getHiddenUnit == hiddenUnit)
+    assert(conf.getWeightShape == weightShape)
+    assert(conf.getFilterSize == filterSize)
+    assert(conf.getStride == stride)
+    assert(conf.featureMapSize == featureMapSize)
+    assert(conf.getKernel == kernel)
+    assert(conf.batchSize == batchSize)
+    assert(conf.numLineSearchIterations == numIterations)
+    assert(conf.minimize == minimize)
+    assert(conf.convolutionType == convolutionType)
+    assert(conf.l1 == l1)
+    assert(conf.getCustomLossFunction == lossFunction.name)
+    assert(conf.rmsDecay == rmsDecay)
+    assert(conf.stepFunction == stepFunction)
+  }
+}


### PR DESCRIPTION
This adds following items:
* NeuralNetConf case class as factory | immutable conf of NeuralNetConfiguration.
* LossFunction classes for type-safed LossFunction / CustomLossFunction in ND4j (it might be a part of ND4s in the future)
* ActivationFunctions classes for type-safety

This also change:
* MultiLayerConf package name (as synonym of DL4j package name)
* MultiLayerConf from object to case class for ease-to-create derivative configuration as follows:

```scala
import org.deeplearning4s.nn.conf._
val defaultConf = MultiLayerConf(Array(1,2))

/*
 Ease to create derivative configuration based on default one,
 with changing only "pretrain" parameter.
*/
val myConf = defaultConf.copy(pretrain = true)

/*
  Also, it's easier to compare configurations based on value equality 
  (v.s. POJO is compared in instance identity.)
*/
val hasChangedConf = myConf != defaultConf
//return true

//asJava method returns Java version (org.deeplearning4j.nn.conf.MultiLayerConfiguration, in this case.)
val javaConf = myConf.asJava
```