### PR TITLE
Fixing some compilation/test errors. (catching up to the latest DL4J's master)

### DIFF
--- a/src/main/scala/org/deeplearning4s/nn/conf/MultiLayerConf.scala
+++ b/src/main/scala/org/deeplearning4s/nn/conf/MultiLayerConf.scala
@@ -1,8 +1,8 @@
 package org.deeplearning4s.nn.conf
 
 import org.deeplearning4j.nn.conf.MultiLayerConfiguration.Builder
+import org.deeplearning4j.nn.conf._
 import org.deeplearning4j.nn.conf.`override`.ConfOverride
-import org.deeplearning4j.nn.conf.{InputPreProcessor, MultiLayerConfiguration, NeuralNetConfiguration, OutputPreProcessor}
 
 import scala.collection.JavaConverters._
 
@@ -12,9 +12,9 @@ case class MultiLayerConf(
                            pretrain: Boolean = false,
                            useRBMPropUpAsActivations: Boolean = false,
                            dampingFactor: Double = 100D,
-                           backward: Boolean = false,
+                           backprop: Boolean = false,
                            inputPreProcessors: Map[Int, InputPreProcessor] = Map.empty,
-                           preProcessors: Map[Int, OutputPreProcessor] = Map.empty,
+                           outputPostProcessors: Map[Int, OutputPostProcessor] = Map.empty,
                            confs: Seq[NeuralNetConfiguration] = Nil,
                            confOverrides: Map[Int, ConfOverride] = Map.empty
                            ) {
@@ -25,9 +25,9 @@ case class MultiLayerConf(
       .pretrain(pretrain)
       .useRBMPropUpAsActivations(useRBMPropUpAsActivations)
       .dampingFactor(dampingFactor)
-      .backward(backward)
-      .inputPreProcessors(inputPreProcessors.map { case (i, p) => (int2Integer(i), p)}.toMap.asJava)
-      .preProcessors(preProcessors.map { case (i, p) => (int2Integer(i), p)}.toMap.asJava)
+      .backprop(backprop)
+      .inputPreProcessors(inputPreProcessors.map { case (i, p) => (int2Integer(i), p) }.toMap.asJava)
+      .outputPostProcessors(outputPostProcessors.map { case (i, p) => (int2Integer(i), p) }.toMap.asJava)
       .confs(confs.asJava)
 
     confOverrides.collect { case (i, co) =>

--- a/src/test/scala/org/deeplearning4j/nn/conf/MultiLayerConfTest.scala
+++ b/src/test/scala/org/deeplearning4j/nn/conf/MultiLayerConfTest.scala
@@ -5,6 +5,7 @@ import org.deeplearning4j.nn.conf.`override`.ConfOverride
 import org.deeplearning4s.nn.conf.MultiLayerConf
 import org.nd4j.linalg.api.ndarray.INDArray
 import org.scalatest.FlatSpec
+
 import scala.collection.JavaConverters._
 
 class MultiLayerConfTest extends FlatSpec {
@@ -14,12 +15,16 @@ class MultiLayerConfTest extends FlatSpec {
     val pretrainV: Boolean = true
     val useRBMPropUpAsActivationsV: Boolean = true
     val dampingFactorV: Double = 1000D
-    val backwardV: Boolean = true
+    val backpropV: Boolean = true
     val inputPreProcessorsV: Map[Int, InputPreProcessor] = Map(1 -> new InputPreProcessor {
+      override def backprop(output: INDArray): INDArray = ???
+
       override def preProcess(input: INDArray): INDArray = ???
     })
-    val preProcessorsV: Map[Int, OutputPreProcessor] = Map(2 -> new OutputPreProcessor {
-      override def preProcess(output: INDArray): INDArray = ???
+    val preProcessorsV: Map[Int, OutputPostProcessor] = Map(2 -> new OutputPostProcessor {
+      override def backprop(input: INDArray): INDArray = ???
+
+      override def process(output: INDArray): INDArray = ???
     })
     val confsV: Seq[NeuralNetConfiguration] = List(new NeuralNetConfiguration())
     val confOverridesV: Map[Int, ConfOverride] = Map(1 -> new ConfOverride {
@@ -31,9 +36,9 @@ class MultiLayerConfTest extends FlatSpec {
       pretrain = pretrainV,
       useRBMPropUpAsActivations = useRBMPropUpAsActivationsV,
       dampingFactor = dampingFactorV,
-      backward = backwardV,
+      backprop = backpropV,
       inputPreProcessors = inputPreProcessorsV,
-      preProcessors = preProcessorsV,
+      outputPostProcessors = preProcessorsV,
       confs = confsV,
       confOverrides = confOverridesV
     ).asJava
@@ -43,9 +48,9 @@ class MultiLayerConfTest extends FlatSpec {
     assert(mlc.pretrain == pretrainV)
     assert(mlc.useRBMPropUpAsActivations == useRBMPropUpAsActivationsV)
     assert(mlc.dampingFactor == dampingFactorV)
-    assert(mlc.backward == backwardV)
-    assert(mlc.inputPreProcessors == inputPreProcessorsV.map{case (i,p) => Integer.valueOf(i)->p}.asJava)
-    assert(mlc.getProcessors == preProcessorsV.map{case (i,p) => Integer.valueOf(i)->p}.asJava)
+    assert(mlc.backprop == backpropV)
+    assert(mlc.inputPreProcessors == inputPreProcessorsV.map { case (i, p) => Integer.valueOf(i) -> p }.asJava)
+    assert(mlc.outputPostProcessors == preProcessorsV.map { case (i, p) => Integer.valueOf(i) -> p }.asJava)
     assert(mlc.confs == confsV.asJava)
   }
 }

--- a/src/test/scala/org/deeplearning4j/optimize/SolverAtTest.scala
+++ b/src/test/scala/org/deeplearning4j/optimize/SolverAtTest.scala
@@ -1,15 +1,18 @@
 package org.deeplearning4j.optimize
 
-import org.deeplearning4j.nn.conf.NeuralNetConfiguration
+import org.deeplearning4j.nn.api.Layer
+import org.deeplearning4j.nn.conf.layers.RBM
+import org.deeplearning4j.nn.layers.factory.LayerFactories
 import org.deeplearning4j.optimize.listeners.ScoreIterationListener
+import org.deeplearning4s.nn.conf.NeuralNetConf
 import org.deeplearning4s.optimize.SolverAt
-import org.deeplearning4s.plot.BarnesHutTsneAt
 import org.scalatest.FlatSpec
 
 class SolverAtTest extends FlatSpec {
   "SolverAt" should "create a solver to return optimizer without exception" in {
-    val conf = new NeuralNetConfiguration()
-    val model = BarnesHutTsneAt()
+    // FIX these sample creation after developing scala bindings for nn.conf.layers and nn.api.layers.
+    val conf = NeuralNetConf(new RBM.Builder(RBM.HiddenUnit.BINARY, RBM.VisibleUnit.BINARY, 1).build()).asJava
+    val model: Layer = LayerFactories.getFactory(conf.getLayer()).create(conf);
     val listeners = Seq(new ScoreIterationListener())
 
     SolverAt(conf, model, listeners).getOptimizer


### PR DESCRIPTION
Fixes compilation/test error due to recent changes in DL4J master.

- `NeuralNetConf`:  introduced/deleted additional parameters.
- `MultiLayerConf`:  
  - rename deleted `OutputPreProcessor` to `OutputPostProcessor`
  - changed to use `backprop` instead of `backward`
- SolverAtTest: changed to use `RBM` instead of `BarnesHutTsne`
  - `BackTrackLineSearch` now required `maxNumLineSearchIterations` in `NeuralNetConfiguration` instance. Thus, `Solver.Builder` can't build `BarnesHutTsne` correctly at default setting, which uses `ConjugateGradient`, because `BarnesHutTsne` doesn't have `NeuralNetworkConfiguration` instance (returns `null`).

