### PR TITLE
ported BasePretrainNetworks (RBM and AutoEncoder)

### DIFF
--- a/src/main/scala/org/deeplearning4s/nn/conf/NeuralNetConf.scala
+++ b/src/main/scala/org/deeplearning4s/nn/conf/NeuralNetConf.scala
@@ -3,11 +3,12 @@ package org.deeplearning4s.nn.conf
 import org.deeplearning4j.nn.api.OptimizationAlgorithm
 import org.deeplearning4j.nn.conf.NeuralNetConfiguration.Builder
 import org.deeplearning4j.nn.conf.distribution.{Distribution, NormalDistribution}
-import org.deeplearning4j.nn.conf.layers.{Layer, RBM, SubsamplingLayer}
+import org.deeplearning4j.nn.conf.layers.{RBM, SubsamplingLayer}
 import org.deeplearning4j.nn.conf.stepfunctions.StepFunction
 import org.deeplearning4j.nn.conf.{NeuralNetConfiguration, Updater}
 import org.deeplearning4j.nn.weights.WeightInit
 import org.deeplearning4s.nn.conf.LossFunction.{Custom, RECONSTRUCTION_CROSSENTROPY}
+import org.deeplearning4s.nn.conf.layers.Layer
 import org.nd4j.linalg.convolution.Convolution
 
 import scala.collection.JavaConverters._
@@ -63,7 +64,7 @@ case class NeuralNetConf(layer: Layer,
     }
 
     val conf = new Builder()
-      .layer(layer)
+      .layer(layer.asJava)
       .sparsity(sparsity)
       .useAdaGrad(useAdaGrad)
       .learningRate(learningRate)

--- a/src/main/scala/org/deeplearning4s/nn/conf/layers/AutoEncoder.scala
+++ b/src/main/scala/org/deeplearning4s/nn/conf/layers/AutoEncoder.scala
@@ -1,0 +1,29 @@
+package org.deeplearning4s.nn.conf.layers
+
+import org.deeplearning4j.nn.conf.Updater
+import org.deeplearning4j.nn.conf.distribution.Distribution
+import org.deeplearning4j.nn.conf.layers.AutoEncoder.Builder
+import org.deeplearning4j.nn.weights.WeightInit
+import org.deeplearning4s.nn.conf.ActivationFunction
+
+case class AutoEncoder(
+                        corruptionLevel: Double = Double.NaN,
+                        sparsity: Double = Double.NaN,
+                        override val nIn: Int = Int.MinValue,
+                        override val nOut: Int = Int.MinValue,
+                        override val activationFunction: ActivationFunction = null,
+                        override val weightInit: WeightInit = null,
+                        override val dist: Distribution = null,
+                        override val dropOut: Double = Double.NaN,
+                        override val updater: Updater = null
+                        ) extends BasePretrainNetwork {
+  def asJava = new Builder(corruptionLevel)
+    .activation(activationFunction.name)
+    .weightInit(weightInit)
+    .dist(dist)
+    .dropOut(dropOut)
+    .updater(updater)
+    .nIn(nIn)
+    .nOut(nOut)
+    .sparsity(sparsity).build()
+}

--- a/src/main/scala/org/deeplearning4s/nn/conf/layers/BasePretrainNetwork.scala
+++ b/src/main/scala/org/deeplearning4s/nn/conf/layers/BasePretrainNetwork.scala
@@ -1,0 +1,3 @@
+package org.deeplearning4s.nn.conf.layers
+
+trait BasePretrainNetwork extends FeedForwardLayer

--- a/src/main/scala/org/deeplearning4s/nn/conf/layers/FeedForwardLayer.scala
+++ b/src/main/scala/org/deeplearning4s/nn/conf/layers/FeedForwardLayer.scala
@@ -1,0 +1,6 @@
+package org.deeplearning4s.nn.conf.layers
+
+trait FeedForwardLayer extends Layer {
+  val nIn: Int = Int.MinValue
+  val nOut: Int = Int.MinValue
+}

--- a/src/main/scala/org/deeplearning4s/nn/conf/layers/Layer.scala
+++ b/src/main/scala/org/deeplearning4s/nn/conf/layers/Layer.scala
@@ -1,0 +1,17 @@
+package org.deeplearning4s.nn.conf.layers
+
+import org.deeplearning4j.nn.conf.layers.{Layer => jLayer}
+import org.deeplearning4j.nn.conf.Updater
+import org.deeplearning4j.nn.conf.distribution.Distribution
+import org.deeplearning4j.nn.weights.WeightInit
+import org.deeplearning4s.nn.conf.ActivationFunction
+
+trait Layer {
+  val activationFunction: ActivationFunction = null
+  val weightInit: WeightInit = null
+  val dist: Distribution = null
+  val dropOut: Double = Double.NaN
+  val updater: Updater = null
+
+  def asJava: jLayer
+}

--- a/src/main/scala/org/deeplearning4s/nn/conf/layers/RBM.scala
+++ b/src/main/scala/org/deeplearning4s/nn/conf/layers/RBM.scala
@@ -1,0 +1,34 @@
+package org.deeplearning4s.nn.conf.layers
+
+import org.deeplearning4j.nn.conf.Updater
+import org.deeplearning4j.nn.conf.distribution.Distribution
+import org.deeplearning4j.nn.conf.layers.{RBM => jRBM}
+import org.deeplearning4j.nn.weights.WeightInit
+import org.deeplearning4s.nn.conf.ActivationFunction
+
+case class RBM(
+                hiddenUnit: jRBM.HiddenUnit = jRBM.HiddenUnit.BINARY,
+                visibleUnit: jRBM.VisibleUnit = jRBM.VisibleUnit.BINARY,
+                k: Int = Int.MinValue,
+                override val nIn: Int = Int.MinValue,
+                override val nOut: Int = Int.MinValue,
+                override val activationFunction: ActivationFunction = null,
+                override val weightInit: WeightInit = null,
+                override val dist: Distribution = null,
+                override val updater: Updater = null,
+                override val dropOut: Double = Double.NaN
+                ) extends BasePretrainNetwork {
+
+  def asJava = new jRBM.Builder()
+    .activation(if (activationFunction == null) null else activationFunction.name)
+    .weightInit(weightInit)
+    .dist(dist)
+    .updater(updater)
+    .dropOut(dropOut)
+    .nIn(nIn)
+    .nOut(nOut)
+    .hiddenUnit(hiddenUnit)
+    .visibleUnit(visibleUnit)
+    .k(k)
+    .build()
+}

--- a/src/test/scala/org/deeplearning4j/nn/conf/NeuralNetConfTest.scala
+++ b/src/test/scala/org/deeplearning4j/nn/conf/NeuralNetConfTest.scala
@@ -2,10 +2,11 @@ package org.deeplearning4j.nn.conf
 
 import org.deeplearning4j.nn.api.OptimizationAlgorithm
 import org.deeplearning4j.nn.conf.distribution.{Distribution, NormalDistribution}
-import org.deeplearning4j.nn.conf.layers.{Layer, RBM, SubsamplingLayer}
+import org.deeplearning4j.nn.conf.layers.{RBM => jRBM, SubsamplingLayer}
 import org.deeplearning4j.nn.conf.stepfunctions.StepFunction
 import org.deeplearning4j.nn.weights.WeightInit
 import org.deeplearning4s.nn.conf.LossFunction.Max
+import org.deeplearning4s.nn.conf.layers.RBM
 import org.deeplearning4s.nn.conf.{ActivationFunction, NeuralNetConf, Sigmoid}
 import org.nd4j.linalg.convolution.Convolution
 import org.scalatest.FlatSpec
@@ -14,13 +15,14 @@ import scala.collection.JavaConverters._
 
 class NeuralNetConfTest extends FlatSpec {
   "NeuralNetConf" should "set each property to MultiLayerConfiguration instance correctly" in {
-    val layer: Layer = new Layer {}
-    // values in Layer will override values in NeuralNetConf.
-    layer.setDropOut(2.0D)
+    val k: Int = 2
+    val layer = RBM(
+      hiddenUnit = jRBM.HiddenUnit.BINARY,
+      visibleUnit = jRBM.VisibleUnit.BINARY,
+      k = k)
     val sparsity: Double = 2f
     val useAdaGrad: Boolean = false
     val learningRate: Double = 1e-2D
-    val k: Int = 2
     val corruptionLevel: Double = 3e-2D
     val numIterations: Int = 200
     val momentum: Double = 1D
@@ -40,8 +42,8 @@ class NeuralNetConfTest extends FlatSpec {
     val nIn: Int = 0
     val nOut: Int = 0
     val activationFunction: ActivationFunction = Sigmoid
-    val visibleUnit: RBM.VisibleUnit = RBM.VisibleUnit.BINARY
-    val hiddenUnit: RBM.HiddenUnit = RBM.HiddenUnit.BINARY
+    val visibleUnit: jRBM.VisibleUnit = jRBM.VisibleUnit.BINARY
+    val hiddenUnit: jRBM.HiddenUnit = jRBM.HiddenUnit.BINARY
     val weightShape: Array[Int] = Array(4, 4)
     val kernelSize: Array[Int] = Array(2, 2)
     val stride: Array[Int] = Array(2, 2)
@@ -60,50 +62,52 @@ class NeuralNetConfTest extends FlatSpec {
     val updater: Updater = Updater.NONE
     val miniBatch: Boolean = false
 
-    val conf = NeuralNetConf(layer,
-      sparsity,
-      useAdaGrad,
-      learningRate,
-      k,
-      corruptionLevel,
-      numIterations,
-      momentum,
-      l2,
-      useRegularization,
-      momentumAfter,
-      resetAdaGradIterations,
-      dropOut,
-      applySparsity,
-      weightInit,
-      optimizationAlgo,
-      lossFunction,
-      constrainGradientToUnitNorm,
-      seed,
-      dist,
-      nIn,
-      nOut,
-      activationFunction,
-      visibleUnit,
-      hiddenUnit,
-      weightShape,
-      kernelSize,
-      stride,
-      padding,
-      batchSize,
-      numLineSearchIterations,
-      maxNumLineSearchIterations,
-      minimize,
-      convolutionType,
-      poolingType,
-      l1,
-      rmsDecay,
-      stepFunction,
-      useDropConnect,
-      rho,
-      updater,
-      miniBatch).asJava
+    val conf = NeuralNetConf(
+      layer = layer,
+      sparsity = sparsity,
+      useAdaGrad = useAdaGrad,
+      learningRate = learningRate,
+      k = k,
+      corruptionLevel = corruptionLevel,
+      numIterations = numIterations,
+      momentum = momentum,
+      l2 = l2,
+      useRegularization = useRegularization,
+      momentumAfter = momentumAfter,
+      resetAdaGradIterations = resetAdaGradIterations,
+      dropOut = dropOut,
+      applySparsity = applySparsity,
+      weightInit = weightInit,
+      optimizationAlgo = optimizationAlgo,
+      lossFunction = lossFunction,
+      constrainGradientToUnitNorm = constrainGradientToUnitNorm,
+      seed = seed,
+      dist = dist,
+      nIn = nIn,
+      nOut = nOut,
+      activationFunction = activationFunction,
+      visibleUnit = visibleUnit,
+      hiddenUnit = hiddenUnit,
+      weightShape = weightShape,
+      kernelSize = kernelSize,
+      stride = stride,
+      padding = padding,
+      batchSize = batchSize,
+      numLineSearchIterations = numLineSearchIterations,
+      maxNumLineSearchIterations = maxNumLineSearchIterations,
+      minimize = minimize,
+      convolutionType = convolutionType,
+      poolingType = poolingType,
+      l1 = l1,
+      rmsDecay = rmsDecay,
+      stepFunction = stepFunction,
+      useDropConnect = useDropConnect,
+      rho = rho,
+      updater = updater,
+      miniBatch = miniBatch
+    ).asJava
 
-    assert(conf.layer == layer)
+    assert(conf.layer == layer.asJava)
     assert(conf.getSparsity == sparsity)
     assert(conf.isUseAdaGrad == useAdaGrad)
     assert(conf.getLr == learningRate)
@@ -115,7 +119,7 @@ class NeuralNetConfTest extends FlatSpec {
     assert(conf.useRegularization == useRegularization)
     assert(conf.momentumAfter.asScala == momentumAfter)
     assert(conf.resetAdaGradIterations == resetAdaGradIterations)
-    assert(conf.dropOut == 2.0D)
+    assert(conf.dropOut == dropOut)
     assert(conf.applySparsity == applySparsity)
     assert(conf.getWeightInit == weightInit)
     assert(conf.optimizationAlgo == optimizationAlgo)

--- a/src/test/scala/org/deeplearning4j/nn/conf/layers/AutoEncoderTest.scala
+++ b/src/test/scala/org/deeplearning4j/nn/conf/layers/AutoEncoderTest.scala
@@ -1,0 +1,44 @@
+package org.deeplearning4j.nn.conf.layers
+
+import org.deeplearning4j.nn.conf.Updater
+import org.deeplearning4j.nn.conf.distribution.{Distribution, NormalDistribution}
+import org.deeplearning4j.nn.weights.WeightInit
+import org.deeplearning4s.nn.conf.layers.{AutoEncoder => sAutoEncoder}
+import org.deeplearning4s.nn.conf.{ActivationFunction, Tanh}
+import org.scalatest.FlatSpec
+
+class AutoEncoderTest extends FlatSpec {
+  "AutoEncoder" should "set each property to org.deeplearning4j.nn.conf.layers.AutoEncoder instance correctly" in {
+    val corruptionLevel: Double = 0.1
+    val sparsity: Double = 0.2
+    val nIn: Int = 10
+    val nOut: Int = 10
+    val activationFunction: ActivationFunction = Tanh
+    val weightInit: WeightInit = WeightInit.VI
+    val dist: Distribution = new NormalDistribution(1e-3, 1)
+    val updater: Updater = Updater.NONE
+    val dropOut: Double = 0.2
+
+    val rbm = sAutoEncoder(
+      corruptionLevel = corruptionLevel,
+      sparsity = sparsity,
+      nIn = 10,
+      nOut = 10,
+      activationFunction = activationFunction,
+      weightInit = weightInit,
+      dist = dist,
+      updater = updater,
+      dropOut = dropOut
+    ).asJava
+
+    assert(rbm.corruptionLevel == corruptionLevel)
+    assert(rbm.sparsity == sparsity)
+    assert(rbm.nIn == nIn)
+    assert(rbm.nOut == nOut)
+    assert(rbm.activationFunction == activationFunction.name)
+    assert(rbm.weightInit == weightInit)
+    assert(rbm.dist == dist)
+    assert(rbm.updater == updater)
+    assert(rbm.dropOut == dropOut)
+  }
+}

--- a/src/test/scala/org/deeplearning4j/nn/conf/layers/RBMTest.scala
+++ b/src/test/scala/org/deeplearning4j/nn/conf/layers/RBMTest.scala
@@ -1,0 +1,48 @@
+package org.deeplearning4j.nn.conf.layers
+
+import org.deeplearning4j.nn.conf.Updater
+import org.deeplearning4j.nn.conf.distribution.{NormalDistribution, Distribution}
+import org.deeplearning4j.nn.conf.layers.{RBM => jRBM}
+import org.deeplearning4j.nn.weights.WeightInit
+import org.deeplearning4s.nn.conf.{Tanh, ActivationFunction}
+import org.deeplearning4s.nn.conf.layers.{RBM => sRBM}
+import org.scalatest.FlatSpec
+
+class RBMTest extends FlatSpec {
+  "RBM" should "set each property to org.deeplearning4j.nn.conf.layers.RBM instance correctly" in {
+    val hiddenUnit: jRBM.HiddenUnit = jRBM.HiddenUnit.BINARY
+    val visibleUnit: jRBM.VisibleUnit = jRBM.VisibleUnit.BINARY
+    val k: Int = 10
+    val nIn: Int = 10
+    val nOut: Int = 10
+    val activationFunction: ActivationFunction = Tanh
+    val weightInit: WeightInit = WeightInit.VI
+    val dist: Distribution = new NormalDistribution(1e-3, 1)
+    val updater: Updater = Updater.NONE
+    val dropOut: Double = 0.2
+
+    val rbm = sRBM(
+      hiddenUnit = hiddenUnit,
+      visibleUnit = visibleUnit,
+      k = k,
+      nIn = 10,
+      nOut = 10,
+      activationFunction = activationFunction,
+      weightInit = weightInit,
+      dist = dist,
+      updater = updater,
+      dropOut = dropOut
+    ).asJava
+
+    assert(rbm.hiddenUnit == hiddenUnit)
+    assert(rbm.visibleUnit == visibleUnit)
+    assert(rbm.k == k)
+    assert(rbm.nIn == nIn)
+    assert(rbm.nOut == nOut)
+    assert(rbm.activationFunction == activationFunction.name)
+    assert(rbm.weightInit == weightInit)
+    assert(rbm.dist == dist)
+    assert(rbm.updater == updater)
+    assert(rbm.dropOut == dropOut)
+  }
+}


### PR DESCRIPTION
I stated working scala bindings for `deeplearning4j.nn.conf.layers`.
`NeuralNetConf` now takes `deepleraning4s.nn.conf.Layer` instance as its input.

As a first step, I ported `RBM` and `AutoEncoder`.