### PR TITLE
NeuralNetConf: catching up to the latest DL4J's master

### DIFF
--- a/src/main/scala/org/deeplearning4s/nn/conf/NeuralNetConf.scala
+++ b/src/main/scala/org/deeplearning4s/nn/conf/NeuralNetConf.scala
@@ -39,11 +39,11 @@ case class NeuralNetConf(layer: Layer,
                          visibleUnit: RBM.VisibleUnit = RBM.VisibleUnit.BINARY,
                          hiddenUnit: RBM.HiddenUnit = RBM.HiddenUnit.BINARY,
                          weightShape: Array[Int] = null,
+                         timeSeriesLength: Int = 1,
                          kernelSize: Array[Int] = Array(2, 2),
                          stride: Array[Int] = Array(2, 2),
                          padding: Array[Int] = Array(0, 0),
                          batchSize: Int = 100,
-                         numLineSearchIterations: Int = 5,
                          maxNumLineSearchIterations: Int = 5,
                          minimize: Boolean = false,
                          convolutionType: Convolution.Type = Convolution.Type.VALID,
@@ -53,7 +53,7 @@ case class NeuralNetConf(layer: Layer,
                          stepFunction: StepFunction = null,
                          useDropConnect: Boolean = false,
                          rho: Double = 0D,
-                         updater: Updater = Updater.NONE,
+                         updater: Updater = Updater.ADAGRAD,
                          miniBatch: Boolean = false
                           ) {
   def asJava: NeuralNetConfiguration = {
@@ -92,10 +92,10 @@ case class NeuralNetConf(layer: Layer,
       .hiddenUnit(hiddenUnit)
       .weightShape(weightShape)
       .kernelSize(kernelSize: _*)
+      .timeSeriesLength(timeSeriesLength)
       .stride(stride)
       .padding(padding)
       .batchSize(batchSize)
-      .numLineSearchIterations(numIterations)
       .maxNumLineSearchIterations(maxNumLineSearchIterations)
       .minimize(minimize)
       .convolutionType(convolutionType)

--- a/src/test/scala/org/deeplearning4j/nn/conf/NeuralNetConfTest.scala
+++ b/src/test/scala/org/deeplearning4j/nn/conf/NeuralNetConfTest.scala
@@ -46,10 +46,10 @@ class NeuralNetConfTest extends FlatSpec {
     val hiddenUnit: jRBM.HiddenUnit = jRBM.HiddenUnit.BINARY
     val weightShape: Array[Int] = Array(4, 4)
     val kernelSize: Array[Int] = Array(2, 2)
+    val timeSeriesLength: Int = 1
     val stride: Array[Int] = Array(2, 2)
     val padding: Array[Int] = Array(1, 1)
     val batchSize: Int = 200
-    val numLineSearchIterations: Int = 100
     val maxNumLineSearchIterations: Int = 100
     val minimize: Boolean = true
     val convolutionType: Convolution.Type = Convolution.Type.VALID
@@ -90,10 +90,10 @@ class NeuralNetConfTest extends FlatSpec {
       hiddenUnit = hiddenUnit,
       weightShape = weightShape,
       kernelSize = kernelSize,
+      timeSeriesLength = 1,
       stride = stride,
       padding = padding,
       batchSize = batchSize,
-      numLineSearchIterations = numLineSearchIterations,
       maxNumLineSearchIterations = maxNumLineSearchIterations,
       minimize = minimize,
       convolutionType = convolutionType,
@@ -137,7 +137,6 @@ class NeuralNetConfTest extends FlatSpec {
     assert(conf.getStride == stride)
     assert(conf.getPadding == padding)
     assert(conf.batchSize == batchSize)
-    assert(conf.numLineSearchIterations == numIterations)
     assert(conf.maxNumLineSearchIterations == maxNumLineSearchIterations)
     assert(conf.minimize == minimize)
     assert(conf.convolutionType == convolutionType)


### PR DESCRIPTION
NeuralNetConfiguration changes:
- add timeSeriesLength
- deleted numLineSearchIterations
- change default value of updater to ADAGRAD.

ref: deeplearning4j/deeplearning4j#551, deeplearning4j/deeplearning4j#554, deeplearning4j/deeplearning4j#555